### PR TITLE
Remove interrupt disabling from QPI port trapping path

### DIFF
--- a/SRC/PORTHAND.ASM
+++ b/SRC/PORTHAND.ASM
@@ -38,10 +38,6 @@ QEMMPortHandler:ASSUME          ds:_DATA                ; RM handler, access loc
 @@QEMMPortHandler2:
                 ; QEMM passes the caller's stack
                 ; Might be too small so we'll switch to our own
-                ; Might also pass the caller's flags so disable interrupts
-                pushf
-                cli
-
                 ; Save current stack + a scratch reg
                 ; Share a stack with the RTC handler
                 ; This should be safe as one should never interrupt the other
@@ -184,6 +180,5 @@ PortHandler:    ASSUME          ds:_TEXT                ; PM handler, can't read
                 mov             bx,SavedSP
                 mov             sp,bx
                 mov             bx,WORD PTR SavedEBX
-                popf                                    ; Enable interrupts
                 clc
                 retf


### PR DESCRIPTION
The QEMM QPI specification explicitly states that the handler is entered with interrupts disabled (and the original IF by the caller is passed as bit 9 in CX). This is the relevant snippet of the documentation:

```
 4) Install its own far routine as the new callback routine, using
    the QPI_SetIOCallback call. Your callback routine will be
    passed the following information:

     AX = Data for output
     CX = Type of I/O (see flag bits defined below)
     DX = Port number
     IF = 0 (interrupts are disabled)

 When the callback routine has finished its work, it should return
 far with all registers other than CX and DX preserved. If the
 routine is called to get input from a port, AX should be modified.
 The bit-mapped word in CX contains the following information:


 IOT_Output     equ   0000000000000100b
     ;      bit 2 is 1 if output,
     ;      0 if input


 IOT_Word      equ   0000000000001000b
     ;      bit 3 is 1 if word I/O,
     ;      0 if byte I/O


 IOT_IF       equ   0000001000000000b
     ;      bit 9 is the same as the
     ;      caller's interrupt flag
```